### PR TITLE
feat: make `compy cache` default to caching all

### DIFF
--- a/src/cli/deno.ts
+++ b/src/cli/deno.ts
@@ -29,7 +29,7 @@ const buildCommand = (cmd: Cmd, description: string) =>
     .description(description)
     .type('egg', new EggType())
     .type('shell', shellType)
-    .arguments('[module:egg] [...args:string]').allowEmpty()
+    .arguments('[module:egg] [...args:string]')
     .option('-e, --shell <shell:shell>', 'Export command as a shell script')
     .stopEarly()
     .action(async ({ shell }, module, ...args) => {
@@ -38,7 +38,7 @@ const buildCommand = (cmd: Cmd, description: string) =>
         const modules = await getEggs();
         for (const module of modules) {
           const native = await loadNative(compy, [cmd], module, args);
-          await runNative(native);
+          await runOrExport(native, shell);
         }
         return;
       }

--- a/src/cli/deno.ts
+++ b/src/cli/deno.ts
@@ -1,7 +1,7 @@
 import { Command, EnumType } from '../../deps/cliffy.ts';
 
 import { Cmd, exportNative, loadNative, runNative, ShellCommand } from '../monorepo.ts';
-import { EggType, getCompy } from './util.ts';
+import { EggType, getCompy, getEggs } from './util.ts';
 
 const shellType = new EnumType(['sh', 'bash', 'zsh', 'ash', 'fish']);
 
@@ -29,11 +29,20 @@ const buildCommand = (cmd: Cmd, description: string) =>
     .description(description)
     .type('egg', new EggType())
     .type('shell', shellType)
-    .arguments('<module:egg> [...args:string]')
+    .arguments('[module:egg] [...args:string]').allowEmpty()
     .option('-e, --shell <shell:shell>', 'Export command as a shell script')
     .stopEarly()
     .action(async ({ shell }, module, ...args) => {
       const compy = await getCompy();
+      if (module === undefined) {
+        const modules = await getEggs();
+        for (const module of modules) {
+          const native = await loadNative(compy, [cmd], module, args);
+          await runNative(native);
+        }
+        return;
+      }
+
       const native = await loadNative(compy, [cmd], module, args);
 
       return await runOrExport(native, shell);


### PR DESCRIPTION
currently all commands required a module, however, for cache I believe it would be nice to be able to cache all at once.
similar to how `yarn` or other package managers would work

in fact because we're changing the whole wrapper here this now applies to all commands, which might not be what we want. 

happy to discuss.